### PR TITLE
Corrected service enable/start bug & improved vBMC stability in case of no vBMC

### DIFF
--- a/ansible/playbooks/infra-server.yml
+++ b/ansible/playbooks/infra-server.yml
@@ -15,6 +15,7 @@
 
 - hosts: infra_servers
   become: yes
+  gather_facts: True
   vars:
 
     - interfaces_ether_interfaces:

--- a/ansible/roles/kea-dhcp4/handlers/main.yml
+++ b/ansible/roles/kea-dhcp4/handlers/main.yml
@@ -1,7 +1,0 @@
-- name: start the kea services
-  systemd:
-    state: started
-    name: "{{item}}"
-    daemon_reload: yes
-  with_items:
-    - "{{kea_services}}"

--- a/ansible/roles/kea-dhcp4/tasks/main.yml
+++ b/ansible/roles/kea-dhcp4/tasks/main.yml
@@ -26,7 +26,7 @@
   when: kea.stat.exists == False
 
 - name: Build and install KEA
-  shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make install"
+  shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j$(nproc) && make install"
   register: build
   fail_when: build.rc != 0
   when: kea.stat.exists == False

--- a/ansible/roles/kea-dhcp4/tasks/main.yml
+++ b/ansible/roles/kea-dhcp4/tasks/main.yml
@@ -26,7 +26,7 @@
   when: kea.stat.exists == False
 
 - name: Build and install KEA
-  shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j$(nproc) && make install"
+  shell: "cd {{kea_build_path}}/kea-{{kea_version}}/ && ./configure --prefix={{kea_path}} && make -j && make install"
   register: build
   fail_when: build.rc != 0
   when: kea.stat.exists == False

--- a/ansible/roles/mr-provisioner/handlers/main.yml
+++ b/ansible/roles/mr-provisioner/handlers/main.yml
@@ -1,7 +1,0 @@
-- name: start mr-provisioner services
-  service:
-    state: started
-    name: "{{item}}"
-    daemon_reload: yes
-  with_items:
-    - "{{mr_provisioner_services}}"

--- a/ansible/roles/mr-provisioner/handlers/main.yml
+++ b/ansible/roles/mr-provisioner/handlers/main.yml
@@ -1,8 +1,7 @@
 - name: start mr-provisioner services
-  systemd:
-    state: restarted
+  service:
+    state: started
     name: "{{item}}"
     daemon_reload: yes
-    enabled: yes
   with_items:
     - "{{mr_provisioner_services}}"

--- a/ansible/roles/mr-provisioner/tasks/main.yml
+++ b/ansible/roles/mr-provisioner/tasks/main.yml
@@ -103,3 +103,13 @@
 
 - name: Create mr-provisioner BMCs and Networks
   shell: "{{mr_provisioner_venv_path}}/bin/python {{mr_provisioner_path}}/bootstrap-provisioner.py"
+  ignore_errors: yes
+
+- name: Start and enable the mrp services
+  systemd:
+    state: restarted
+    name: "{{item}}"
+    daemon_reload: yes
+    enabled: yes
+  with_items:
+    - "{{mr_provisioner_services}}"

--- a/ansible/roles/mr-provisioner/templates/bootstrap-provisioner.py.j2
+++ b/ansible/roles/mr-provisioner/templates/bootstrap-provisioner.py.j2
@@ -21,13 +21,14 @@ def main():
         db.session.add(network)
         db.session.commit()
         {% endfor %}
+	{% if mr_provisioner_bmcs is not none %}
         {% for bmc in mr_provisioner_bmcs %}
         bmc = BMC(name="{{bmc.name}}", ip="{{bmc.ip}}", privilege_level="{{bmc.privilege_level}}", bmc_type="{{bmc_type|default('plain')}}",
                   username="{{bmc.username}}", password="{{bmc.password}}")
         db.session.add(bmc)
         db.session.commit()
-        {% endfor %}
-
+	{% endfor %}
+	{% endif %}
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Concerning the service enable/start, I noticed kea-dhcp4 was getting properly activated so I copied the kea ansible behaviour. Not sure if the handler part is necessary anymore.
Added template if check for the virutal BMCs, improves stability but it doesn't go through and still fails with SQLAlchemy errors when there are no vBMCs to be found....

Logs can be found here :
[mrpansible_bmc_errror.txt](https://github.com/niedbalski/infra-automation/files/1699236/mrpansible_bmc_errror.txt)
